### PR TITLE
Correct namespace in privacy provider.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_archive\privacy;
+namespace quiz_downloadsubmissions\privacy;
 
 defined('MOODLE_INTERNAL') || die();
 


### PR DESCRIPTION
Throws

Fatal error: Cannot declare class …, because the name is already in use in …/moodle/mod/quiz/report/downloadsubmissions/classes/privacy/provider.php on line 38

otherwise in a full Behat run.

Thanks!

(And sorry to suggesting this in the first place…)