### PR TITLE
Compatibility with Moodle 4.2+

### DIFF
--- a/report.php
+++ b/report.php
@@ -16,8 +16,8 @@
 
 /**
  * This file defines the quiz downloadsubmissions report class.
- * Support for randomly selected essay questions included 
- * as suggested by gabriosecco 
+ * Support for randomly selected essay questions included
+ * as suggested by gabriosecco
  * (https://github.com/IITBombayWeb/moodle-quiz_downloadsubmissions/issues/2#issuecomment-613266125)
  *
  * @package   quiz_downloadsubmissions
@@ -29,7 +29,14 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/mod/quiz/report/attemptsreport.php');
+// This work-around is required until Moodle 4.2 is the lowest version we support.
+if (class_exists('\mod_quiz\local\reports\attempts_report')) {
+    class_alias('\mod_quiz\local\reports\attempts_report', '\quiz_downloadsubmissions_report_parent_alias');
+} else {
+    require_once($CFG->dirroot . '/mod/quiz/report/attemptsreport.php');
+    class_alias('\quiz_attempts_report', '\quiz_downloadsubmissions_report_parent_alias');
+}
+
 require_once($CFG->dirroot . '/mod/quiz/report/downloadsubmissions/downloadsubmissions_form.php');
 
 /**
@@ -41,7 +48,7 @@ require_once($CFG->dirroot . '/mod/quiz/report/downloadsubmissions/downloadsubmi
  * @copyright 1999 onwards Martin Dougiamas and others {@link http://moodle.com}
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class quiz_downloadsubmissions_report extends quiz_attempts_report {
+class quiz_downloadsubmissions_report extends quiz_downloadsubmissions_report_parent_alias {
 
 	public function display($quiz, $cm, $course) {
         global $OUTPUT, $DB;


### PR DESCRIPTION
The current version is not compatible with Moodle 4.2 and newer, because the `quiz_attempts_report` class has been renamed in order to work with the class autoloader.

This PR adds compatibility with 4.2 and newer while maintaining backwards compatibility with Moodle 4.1 and older.