### PR TITLE
Add .txt extension to text file

### DIFF
--- a/report.php
+++ b/report.php
@@ -16,8 +16,8 @@
 
 /**
  * This file defines the quiz downloadsubmissions report class.
- * Support for randomly selected essay questions included 
- * as suggested by gabriosecco 
+ * Support for randomly selected essay questions included
+ * as suggested by gabriosecco
  * (https://github.com/IITBombayWeb/moodle-quiz_downloadsubmissions/issues/2#issuecomment-613266125)
  *
  * @package   quiz_downloadsubmissions
@@ -395,7 +395,7 @@ class quiz_downloadsubmissions_report extends quiz_attempts_report {
 	    		if ($textfile) {
 	    		    $zipfilename = $textfile->get_filename();
 // 	    		    $pathfilename = $pathprefix . $textfile->get_filepath() . $prefix3 . $zipfilename;
-	    		    $pathfilename = $pathprefix . $textfile->get_filepath() . $prefix3 . 'textresponse';
+	    		    $pathfilename = $pathprefix . $textfile->get_filepath() . $prefix3 . 'textresponse.txt';
 	    		    $pathfilename = clean_param($pathfilename, PARAM_PATH);
 	    		    $filesforzipping[$pathfilename] = $textfile;
 	    		}


### PR DESCRIPTION
Some users are not very tech-savvy and thus do not know how they can open a plain-text file that does not have an extension.

This PR makes sure that the text files will have the `.txt` extension and will help those users.